### PR TITLE
fix : header 비교 드롭다운 메뉴 잘림 해결

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -32,7 +32,7 @@ header {
   width: 100%;
   height: 90px;
   background-color: white; /* 배경색 지정하여 아래 요소와 겹침 방지 */
-  z-index: 2000;
+  z-index: 2001;
   border-bottom: 1px solid var(--divider-border);
   color: var(--font1);
   padding: 10px 5%;


### PR DESCRIPTION
# MyNav 상단 스크롤 고정으로 인한 Header 드롭다운메뉴 잘림 해결


## 수정 전
![image](https://github.com/user-attachments/assets/ce505f2d-599a-4f60-9fcf-81b4691e885c)
`z-index: 2000;`

## 수정 후
![image](https://github.com/user-attachments/assets/11781b82-4793-4b9a-858f-bc2d795d674e)
`z-index: 2001;`

---
z-index 높여 해결