### PR TITLE
feat :  사용자 목록 조회 및 검색 api 연동 완료

### DIFF
--- a/src/pages/AdminMainPage/AdminMainPage.jsx
+++ b/src/pages/AdminMainPage/AdminMainPage.jsx
@@ -1,11 +1,65 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import styles from './AdminMainPage.module.scss';
 import { Line } from 'react-chartjs-2';
 import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend } from 'chart.js';
+import { PATH } from "src/utils/path";
+import userLogo from 'src/assets/icons/userIcon.png'
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
 
 const AdminMainPage = () => {
+    const [newUsers, setNewUsers] = useState([]);  // 신규 회원 데이터를 저장
+    const [inquireList, setInquireList] = useState([]);  // 신규 회원 데이터를 저장
+    const token = localStorage.getItem("authToken");
+
+    // 신규 회원 데이터를 가져오는 함수
+    const fetchNewUsers = async (page = 0) => {
+        try {
+            const response = await fetch(
+                `${PATH.SERVER}/api/userList?page=${page}&size=4`, {
+                method: "GET",
+                headers: { Authorization: `Bearer ${token}` },
+            }
+            );
+            const data = await response.json();
+
+            if (data.success) {
+                setNewUsers(data.result.content); // 회원 데이터 저장
+            } else {
+                console.error("유저 목록 조회 실패:", data.message);
+            }
+        } catch (error) {
+            console.error("API 호출 중 오류:", error);
+        }
+    };
+
+    const fetchInquiryList = async (page = 0) => {
+        try {
+            const response = await fetch(
+                `${PATH.SERVER}/api/chatrooms/inquireList?page=${page}&size=4`, {
+                method: "GET",
+                headers: { Authorization: `Bearer ${token}` },
+            }
+            );
+            const data = await response.json();
+
+            if (data.success) {
+                setInquireList(data.result.content); // 회원 데이터 저장
+            } else {
+                console.error("유저 목록 조회 실패:", data.message);
+            }
+        } catch (error) {
+            console.error("API 호출 중 오류:", error);
+        }
+    }
+
+    // 컴포넌트가 마운트될 때 데이터 가져오기
+    useEffect(() => {
+        fetchNewUsers();
+        fetchInquiryList();
+    }, []);
+
+
     const data = {
         labels: ['12-05', '12-06', '12-07', '12-08', '12-09', '12-10', '12-11'], // 날짜 라벨
         datasets: [
@@ -67,7 +121,7 @@ const AdminMainPage = () => {
                         <div className={styles.dashboardItemHeader}>
                             <div className={styles.dashboardItemTitle}>
                                 <h4>방문자 현황</h4>
-                            </div>                            
+                            </div>
                         </div>
                         {/* 방문자 현황 body : 그래프 */}
                         <div className={styles.dashboardItemBody}>
@@ -145,7 +199,7 @@ const AdminMainPage = () => {
                     </div>
                 </div>
             </div>
-             {/* 두번째 행 영역 */}
+            {/* 두번째 행 영역 */}
             <div className={styles.dashboardRow}>
                 {/* 3. 신규 회원 영역 */}
                 <div className={styles.dashboardItemArea}>
@@ -158,25 +212,24 @@ const AdminMainPage = () => {
                         {/* 신규 회원 body */}
                         <div className={styles.dashboardItemBody}>
                             <ul className={styles.newUserList}>
-                                {[
-                                    { name: "김유진", email: "yu****@example.com", date: "2024-11-14" },
-                                    { name: "박현지", email: "ph****@example.com", date: "2024-11-14" },
-                                    { name: "이준호", email: "lj****@example.com", date: "2024-11-14" },
-                                    { name: "정하나", email: "jh****@example.com", date: "2024-11-14" },
-                                    { name: "정하나", email: "jh****@example.com", date: "2024-11-14" },
-                                    { name: "정하나", email: "jh****@example.com", date: "2024-11-14" },
-                                ].map((user, index) => (
-                                    <li key={index} className={styles.newUserItem}>
-                                        <div className={styles.profileImage}>
-                                            <img src="/src/assets/icons/userIcon.png" alt='사용자 프로필'></img>
-                                        </div>
-                                        <div className={styles.userInfo}>
-                                            <span className={styles.userName}>{user.name}</span>
-                                            <span className={styles.userEmail}>{user.email}</span>
-                                        </div>
-                                        <div className={styles.joinDate}>{user.date}</div>
-                                    </li>
-                                ))}
+                                {newUsers.map((user) => {
+                                    return ( // 명시적으로 반환
+                                        <li key={user.id} className={styles.newUserItem}>
+                                            <div className={styles.profileImage}>
+                                                <img src={userLogo} alt="사용자 프로필"></img>
+                                            </div>
+                                            <div className={styles.userInfo}>
+                                                <span className={styles.userName}>{user.username}</span>
+                                                <span className={styles.userEmail}>{user.email}</span>
+                                            </div>
+                                            <div className={styles.joinDate}>
+                                                {user.createdAt
+                                                    ? new Date(user.createdAt).toLocaleDateString()
+                                                    : "알 수 없음"}
+                                            </div>
+                                        </li>
+                                    );
+                                })}
                             </ul>
                         </div>
                     </div>
@@ -192,53 +245,40 @@ const AdminMainPage = () => {
                         {/* 1:1 문의 내역 body */}
                         <div className={styles.dashboardItemBody}>
                             <ul className={styles.inquiryList}>
-                                {[
-                                    {
-                                        title: "게시판 작성 위젯별 기능 설명(상단전용)",
-                                        author: "관리자",
-                                        date: "2020-12-11 14:38",
-                                        badge: "N"
-                                    },
-                                    {
-                                        title: "게시판 작성 상단 디자인 설정 주요 기능 알아보기",
-                                        author: "관리자",
-                                        date: "2020-12-10 14:48"
-                                    },
-                                    {
-                                        title: "게시판 작성 커스텀 하단 만들기(푸터)",
-                                        author: "관리자",
-                                        date: "2020-12-10 14:36"
-                                    },
-                                    {
-                                        title: "게시판 작성 하단 설정하기(푸터)",
-                                        author: "관리자",
-                                        date: "2020-12-10 11:06"
-                                    },
-                                    {
-                                        title: "게시판 작성 하단 설정하기(푸터)",
-                                        author: "관리자",
-                                        date: "2020-12-10 11:06"
-                                    },
-                                    {
-                                        title: "게시판 작성 하단 설정하기(푸터)",
-                                        author: "관리자",
-                                        date: "2020-12-10 11:06"
-                                    },
-                                ].map((item, index) => (
-                                    <li key={index} className={styles.inquiryItem}>
-                                        <div className={styles.profileImage}>
-                                            <img src="/src/assets/icons/userIcon.png" alt="사용자 프로필" />
-                                        </div>
-                                        <div className={styles.inquiryContent}>
-                                            <div className={styles.inquiryTitle}>
-                                                {item.title} {item.badge && <span className={styles.newBadge}>{item.badge}</span>}
+                                {inquireList.map((inquire) => {
+                                    return (
+                                        <li key={inquire.id} className={styles.inquiryItem}>
+                                            <div className={styles.profileImage}>
+                                                <img src={userLogo} alt="사용자 프로필"></img>
                                             </div>
-                                            <div className={styles.inquiryMeta}>
-                                                <span>{item.author}</span> | <span>{item.date}</span>
+                                            <div className={styles.inquiryContent}>
+                                                <div className={styles.inquiryTitle}>
+                                                    {inquire.topicName}
+                                                    {inquire.status && (
+                                                        <span
+                                                            className={`${styles.newBadge} ${inquire.status === "OPEN" ? styles.openStatus : styles.closedStatus
+                                                                }`}
+                                                        >
+                                                            {inquire.status === "OPEN" ? "OPEN" : "CLOSED"}
+                                                        </span>
+                                                    )}
+                                                </div>
+                                                <div className={styles.inquiryMeta}>
+                                                    <span>{inquire.userName}</span> |
+                                                    <span className={styles.inquiryDate}>
+                                                        {inquire.updatedAt
+                                                            ? `${new Date(inquire.updatedAt).toLocaleDateString()} ${new Date(inquire.updatedAt).toLocaleTimeString([], {
+                                                                hour: '2-digit',
+                                                                minute: '2-digit',
+                                                            })}`
+                                                            : "알 수 없음"}
+                                                    </span>
+                                                </div>
+
                                             </div>
-                                        </div>
-                                    </li>
-                                ))}
+                                        </li>
+                                    );
+                                })}
                             </ul>
                         </div>
                     </div>

--- a/src/pages/AdminMainPage/AdminMainPage.module.scss
+++ b/src/pages/AdminMainPage/AdminMainPage.module.scss
@@ -184,18 +184,29 @@
                                     margin-bottom: 4px;
 
                                     .newBadge {
-                                        background: #ff4500;
                                         color: var(--white);
                                         font-size: 12px;
                                         padding: 2px 6px;
                                         border-radius: 12px;
-                                        margin-left: 8px;
+                                        margin-left: 8px;                                       
+                                    }
+                                    .openStatus {
+                                        background-color: rgb(0, 86, 179); /* 파란색 배경 */
+                                    }
+                                    
+                                    .closedStatus {
+                                        background-color: rgb(211, 211, 211); /* 회색 배경 */
+                                        color: rgb(136, 136, 136); /* 어두운 회색 글씨 */
                                     }
                                 }
 
                                 .inquiryMeta {
                                     font-size: 12px;
                                     color: #666;
+
+                                    .inquiryDate{
+                                        margin-left: 5px;
+                                    }
                                 }
                             }
                         }

--- a/src/pages/AdminUserListPage/AdminUserListPage.jsx
+++ b/src/pages/AdminUserListPage/AdminUserListPage.jsx
@@ -1,7 +1,64 @@
-import React from 'react';
+import React, { useState, useEffect } from "react";
 import styles from './AdminUserListPage.module.scss'
+import { PATH } from "src/utils/path";
 
 const AdminUserListPage = () => {
+    const [users, setUsers] = useState([]); // 사용자 데이터
+    const [currentPage, setCurrentPage] = useState(0); // 현재 페이지
+    const [totalPages, setTotalPages] = useState(0); // 총 페이지 수
+    const token = localStorage.getItem("authToken");
+    const [searchType, setSearchType] = useState("email"); // 검색 타입
+    const [keyword, setKeyword] = useState(""); // 검색어
+
+    const fetchNewUsers = async (page = 0, searchTypeParam = searchType, keywordParam = keyword) => {
+        try {
+            const queryParams = new URLSearchParams({
+                page: page,
+                size: 4,
+            });
+
+            // 검색 조건이 있을 경우만 쿼리에 추가
+            if (typeof keywordParam === "string" && keywordParam.trim()) {
+                queryParams.append("searchType", searchTypeParam);
+                queryParams.append("keyword", keywordParam.trim());
+            }
+
+            const response = await fetch(
+                `${PATH.SERVER}/api/userList?${queryParams.toString()}`,
+                {
+                    method: "GET",
+                    headers: { Authorization: `Bearer ${token}` },
+                }
+            );
+            const data = await response.json();
+
+            if (data.success) {
+                setUsers(data.result.content);
+                setTotalPages(data.result.totalPages);
+                setCurrentPage(page); // 현재 페이지 상태 업데이트
+            } else {
+                console.error("유저 목록 조회 실패:", data.message);
+            }
+        } catch (error) {
+            console.error("API 호출 중 오류:", error);
+        }
+    };
+
+    useEffect(() => {
+        fetchNewUsers(currentPage); // 페이지 변경 시 사용자 데이터 불러오기
+    }, [currentPage]);
+
+    const handleSearch = () => {
+        setCurrentPage(0); // 페이지를 첫 페이지로 리셋
+        fetchNewUsers(0, searchType, keyword); // 검색 조건과 함께 첫 페이지 조회
+    };
+
+    const handlePageChange = (newPage) => {
+        if (newPage >= 0 && newPage < totalPages && newPage !== currentPage) {
+            setCurrentPage(newPage);
+        }
+    };
+
     return (
         <div className={styles.userListDiv}>
             <div className={styles.userListArea}>
@@ -11,62 +68,49 @@ const AdminUserListPage = () => {
                         <h4>사용자 조회</h4>
                     </div>
                     <div className={styles.userSearchBar}>
-                        <select>
+                        <select value={searchType} onChange={(e) => setSearchType(e.target.value)}>
                             <optgroup label="검색 항목">
-                                <option value="id" selected>아이디</option>
+                                <option value="email">이메일</option>
                                 <option value="name">이름</option>
                             </optgroup>
                         </select>
-                        
-                        <input type="text" placeholder="검색어" />
-                        <button>조회</button>
+                        <input
+                            type="text"
+                            placeholder="검색어"
+                            value={keyword}
+                            onChange={(e) => setKeyword(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter") {
+                                    handleSearch();
+                                }
+                            }}
+                        />
+                        <button onClick={handleSearch}>조회</button>
                     </div>
                 </div>
+
+                {/* 사용자 목록 테이블 */}
                 <div className={styles.userListTable}>
                     <table>
                         <thead>
                             <tr>
-                                <th>아이디</th>
+                                <th>이메일</th>
                                 <th>이름</th>
                                 <th>그룹 (역할)</th>
                                 <th>가입일자</th>
                             </tr>
                         </thead>
                         <tbody>
-                            {[
-                                {
-                                    id: 'ADMIN',
-                                    name: '관리자',
-                                    group: '관리자',
-                                    created_at: '2023-07-12 16:53:33',
-                                },
-                                {
-                                    id: 'HONG',
-                                    name: '홍재헌',
-                                    group: '사용자',
-                                    created_at: '2023-07-13 16:53:33',
-                                },
-                                {
-                                    id: 'PARK',
-                                    name: '박채연',
-                                    group: '사용자',
-                                    created_at: '2023-07-14 16:53:33',
-                                },
-                                {
-                                    id: 'OH',
-                                    name: '오영수',
-                                    group: '사용자',
-                                    created_at: '2023-07-18 16:53:33',
-                                },                                
-                            ].map((user, index) => (
-                                <tr
-                                    key={index} 
-                                    className={styles.row}
-                                >
-                                    <td>{user.id}</td>
-                                    <td>{user.name}</td>
-                                    <td>{user.group}</td>
-                                    <td>{user.created_at}</td>
+                            {users.map((user) => (
+                                <tr key={user.id} className={styles.row}>
+                                    <td>{user.email}</td>
+                                    <td>{user.username}</td>
+                                    <td>{user.role}</td>
+                                    <td>
+                                        {user.createdAt
+                                            ? new Date(user.createdAt).toLocaleDateString()
+                                            : "알 수 없음"}
+                                    </td>
                                 </tr>
                             ))}
                         </tbody>
@@ -76,11 +120,27 @@ const AdminUserListPage = () => {
                 {/* 페이지네이션 */}
                 <div className={styles.pagination}>
                     <div className={styles.pageBtn}>
-                        <button disabled>Previous</button>
-                        <button className={styles.active}>1</button>
-                        <button>2</button>
-                        <button>3</button>
-                        <button>Next</button>
+                        <button
+                            onClick={() => handlePageChange(currentPage - 1)}
+                            disabled={currentPage === 0}
+                        >
+                            Previous
+                        </button>
+                        {Array.from({ length: totalPages }, (_, index) => (
+                            <button
+                                key={index}
+                                onClick={() => handlePageChange(index)}
+                                className={currentPage === index ? styles.active : ""}
+                            >
+                                {index + 1}
+                            </button>
+                        ))}
+                        <button
+                            onClick={() => handlePageChange(currentPage + 1)}
+                            disabled={currentPage === totalPages - 1}
+                        >
+                            Next
+                        </button>
                     </div>
                 </div>
             </div>
@@ -89,3 +149,4 @@ const AdminUserListPage = () => {
 };
 
 export default AdminUserListPage;
+


### PR DESCRIPTION
### 사용자 목록 조회 및 검색

- 기본적으로 관리자만 사용할 수 있는 api입니다
![image](https://github.com/user-attachments/assets/47ea61c9-b811-40cd-b54d-70578518ea03)

- 사용자 검색 페이지 (페이징은 페이지마다 4개로 설정, 회원 가입한 순으로 불러옴)
![image](https://github.com/user-attachments/assets/6d66be2e-5527-493e-b06f-bd57d4f50742)

- 이메일 검색 (철자만 검색해도 조회 가능)
![image](https://github.com/user-attachments/assets/99f810ed-a0d1-453b-9f1b-7cdc0d99b436)


- 이름 검색 (위와 동일)
![image](https://github.com/user-attachments/assets/8ca46bb7-d444-477d-9730-9600c3044c0d)

- 페이징 처리

- 페이지 1
![image](https://github.com/user-attachments/assets/694a5b2e-a0da-4cf1-beee-99fcbc94a423)

- 페이지 2
![image](https://github.com/user-attachments/assets/23c2d1a3-4b6b-4211-9350-367de7e9bc6e)


### 관리자 메인 페이지 api 연동

- 사진과 같이 신규 회원란과 1:1 문의 내역란에 api 연동을 진행
- 특히 1:1 문의 내역란에 아직 문의 종료가 안된 것은 "OPEN", 문의 종료된 것은 "CLOSED" 표시로 나옴
![image](https://github.com/user-attachments/assets/306c3057-c95c-4a12-b94b-0fa7fd2095a9)


- 나머지 방문자 현황과 일자별 요약은 요구사항 정립 후 진행 예정입니다
