### PR TITLE
fix : App.css 조정 (<main> 없어도 <Footer /> 가 화면 하단에 붙어있도록 수정)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -8,4 +8,8 @@
 
 .app {
   background-color: #fff;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }


### PR DESCRIPTION
# 수정한 기능
- 사용자 페이지 푸터가 항상 아래에 배치하도록 수정

# 상세내용 
- 사용자 페이지에 내용이 없으면 푸터가 `<Header/>`에 붙어서 나옴
- 이를 해결하기 위해 .app css 조정
- `App.css` 의 `<div className="app">` 에 아래 코드 추가
```
  min-height: 100vh; 
  display: flex;
  flex-direction: column;
  justify-content: space-between;
```


## 변경 전
![image](https://github.com/user-attachments/assets/3b1544d3-7960-4509-86c8-8c19bebc6463)


## 변경 후
![image](https://github.com/user-attachments/assets/b13893e5-1ffb-46da-b39c-05e68d294b52)
