### PR TITLE
관리자 메인 페이지 그래프 및  일자별 요약 api 연동 완료

### DIFF
--- a/src/pages/AdminInquirePage/AdminInquirePage.jsx
+++ b/src/pages/AdminInquirePage/AdminInquirePage.jsx
@@ -285,7 +285,7 @@ const AdminInquirePage = () => {
                                     placeholder='메세지 입력'
                                     value={inputMessage}
                                     onChange={(e) => setInputMessage(e.target.value)}
-                                    onKeyPress={handleKeyPress} // Enter 입력 이벤트 추가
+                                    onKeyDown={handleKeyPress} // Enter 입력 이벤트 추가
                                 />
                                 {inputMessage.trim() && (
                                     <button className={styles.sendButton} onClick={handleSendMessage}>

--- a/src/pages/AdminMainPage/AdminMainPage.jsx
+++ b/src/pages/AdminMainPage/AdminMainPage.jsx
@@ -8,6 +8,13 @@ import userLogo from 'src/assets/icons/userIcon.png'
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
 
 const AdminMainPage = () => {
+    // 방문자 현황 체크
+    const [visitorSummary, setVisitorSummary] = useState({
+        today: { visitorCount: 0, newMembersCount: 0, inquiriesCount: 0 },
+        last4Days: [],
+        last7DaysTotal: 0,
+        thisMonthTotal: 0
+    });
     const [newUsers, setNewUsers] = useState([]);  // 신규 회원 데이터를 저장
     const [inquireList, setInquireList] = useState([]);  // 신규 회원 데이터를 저장
     const token = localStorage.getItem("authToken");
@@ -53,35 +60,70 @@ const AdminMainPage = () => {
         }
     }
 
+    const fetchVisitorSummary = async () => {
+        try {
+            const response = await fetch(`${PATH.SERVER}/api/visitor-summary`, {
+                method: "GET",
+                headers: { Authorization: `Bearer ${token}` }
+            });
+            const data = await response.json();
+
+            if (data.success) {
+                setVisitorSummary(data.result); // 상태에 데이터 저장
+            } else {
+                console.error("방문자 요약 조회 실패:", data.message);
+            }
+        } catch (error) {
+            console.error("API 호출 중 오류:", error);
+        }
+    };
+
     // 컴포넌트가 마운트될 때 데이터 가져오기
     useEffect(() => {
         fetchNewUsers();
         fetchInquiryList();
+        fetchVisitorSummary();
     }, []);
 
 
     const data = {
-        labels: ['12-05', '12-06', '12-07', '12-08', '12-09', '12-10', '12-11'], // 날짜 라벨
+        labels: ['오늘', '최근 7일', '이번 달'], // X축 라벨
         datasets: [
             {
                 label: '총 방문자 수',
-                data: [2, 5, 3, 10, 4, 3, 0], // 총 방문자 수 데이터
+                data: [
+                    visitorSummary.today.visitorCount,   // 오늘 방문자 수
+                    visitorSummary.last7DaysTotal.visitorCount, // 최근 7일 방문자 수
+                    visitorSummary.thisMonthTotal.visitorCount  // 이번 달 방문자 수
+                ],
                 borderColor: 'rgba(255, 99, 132, 1)',
                 backgroundColor: 'rgba(255, 99, 132, 0.2)',
-                fill: true, // 영역 채우기
-                tension: 0.4, // 부드러운 곡선
-                pointBackgroundColor: 'rgba(255, 99, 132, 1)',
-                borderWidth: 1,
+                fill: true,
+                tension: 0.4,
             },
             {
-                label: '방문자 수',
-                data: [1, 2, 4, 6, 2, 3, 0], // 금일 방문자 수 데이터
+                label: '신규 가입자 수',
+                data: [
+                    visitorSummary.today.newMembersCount,  // 오늘 신규 가입자 수
+                    visitorSummary.last7DaysTotal.newMembersCount, // 최근 7일 신규 가입자 수
+                    visitorSummary.thisMonthTotal.newMembersCount  // 이번 달 신규 가입자 수
+                ],
                 borderColor: 'rgba(54, 162, 235, 1)',
                 backgroundColor: 'rgba(54, 162, 235, 0.2)',
                 fill: true,
                 tension: 0.4,
-                pointBackgroundColor: 'rgba(54, 162, 235, 1)',
-                borderWidth: 1,
+            },
+            {
+                label: '문의 수',
+                data: [
+                    visitorSummary.today.inquiriesCount,  // 오늘 문의 수
+                    visitorSummary.last7DaysTotal.inquiriesCount, // 최근 7일 문의 수
+                    visitorSummary.thisMonthTotal.inquiriesCount  // 이번 달 문의 수
+                ],
+                borderColor: 'rgba(75, 192, 192, 1)',
+                backgroundColor: 'rgba(75, 192, 192, 0.2)',
+                fill: true,
+                tension: 0.4,
             },
         ],
     };
@@ -143,61 +185,57 @@ const AdminMainPage = () => {
                                 <thead>
                                     <tr>
                                         <th>일자</th>
-                                        <th>방문자 수</th>
+                                        <th>회원 방문자 수</th>
+                                        <th>비회원 방문자 수</th>
+                                        <th>총 방문자 수</th>
                                         <th>가입</th>
                                         <th>문의 수</th>
                                     </tr>
                                 </thead>
                                 <tbody>
                                     <tr>
-                                        <td>2024-11-14</td>
-                                        <td>10</td>
-                                        <td>12</td>
-                                        <td>2</td>
+                                        <td>{visitorSummary.today.visitDate || "오늘"}</td>
+                                        <td>{visitorSummary.today.membersCount || 0}</td>
+                                        <td>{visitorSummary.today.todayGuestCount || 0}</td>
+                                        <td>{visitorSummary.today.totalMembersCount || 0}</td>
+                                        <td>{visitorSummary.today.newMembersCount || 0}</td>
+                                        <td>{visitorSummary.today.inquiriesCount || 0}</td>
                                     </tr>
-                                    <tr>
-                                        <td>2024-11-13</td>
-                                        <td>10</td>
-                                        <td>32</td>
-                                        <td>0</td>
-                                    </tr>
-                                    <tr>
-                                        <td>2024-11-12</td>
-                                        <td>9</td>
-                                        <td>2</td>
-                                        <td>1</td>
-                                    </tr>
-                                    <tr>
-                                        <td>2024-11-12</td>
-                                        <td>9</td>
-                                        <td>2</td>
-                                        <td>1</td>
-                                    </tr>
-                                    <tr>
-                                        <td>2024-11-12</td>
-                                        <td>9</td>
-                                        <td>2</td>
-                                        <td>1</td>
-                                    </tr>
+
+                                    {visitorSummary.last4Days.map((day, index) => (
+                                        <tr key={index}>
+                                            <td>{day.visitDate}</td>
+                                            <td>{day.memberVisitorsCount}</td>
+                                            <td>{day.guestVisitorsCount}</td>
+                                            <td>{day.totalVisitorsCount}</td>
+                                            <td>{day.newMembersCount}</td>
+                                            <td>{day.inquiriesCount}</td>
+                                        </tr>
+                                    ))}
                                 </tbody>
                                 <tfoot>
                                     <tr>
                                         <td>최근 7일 합계</td>
-                                        <td>55</td>
-                                        <td>55</td>
-                                        <td>20</td>
+                                        <td>{visitorSummary.last7DaysTotal.visitorMemberCount}</td>
+                                        <td>{visitorSummary.last7DaysTotal.visitorGuestCount}</td>
+                                        <td>{visitorSummary.last7DaysTotal.visitorTotalCount}</td>
+                                        <td>{visitorSummary.last7DaysTotal.newMembersCount}</td>
+                                        <td>{visitorSummary.last7DaysTotal.inquiriesCount}</td>
                                     </tr>
                                     <tr>
                                         <td>이번달 합계</td>
-                                        <td>100</td>
-                                        <td>99</td>
-                                        <td>46</td>
+                                        <td>{visitorSummary.thisMonthTotal.visitorMemberCount}</td>
+                                        <td>{visitorSummary.thisMonthTotal.visitorGuestCount}</td>
+                                        <td>{visitorSummary.thisMonthTotal.visitorTotalCount}</td>
+                                        <td>{visitorSummary.thisMonthTotal.newMembersCount}</td>
+                                        <td>{visitorSummary.thisMonthTotal.inquiriesCount}</td>
                                     </tr>
                                 </tfoot>
                             </table>
                         </div>
                     </div>
                 </div>
+
             </div>
             {/* 두번째 행 영역 */}
             <div className={styles.dashboardRow}>

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -8,6 +8,7 @@ import scatterHana from 'src/assets/images/scatterHana.png';
 import scatterWoori from 'src/assets/images/scatterWoori.png';
 import scatterShinhan from 'src/assets/images/scatterShinhan.png';
 import homeBGPhone from "src/assets/images/homeBGPhone.png";
+import { trackVisitor } from "src/utils/visitorTracker";
 
 const HomePage = () => {
     const [scatterCollapsed, setScatterCollapsed] = useState(false);
@@ -17,6 +18,9 @@ const HomePage = () => {
     const [phoneFrameFullVisible, setPhoneFrameFullVisible] = useState(false);
 
     useEffect(() => {
+        // 방문자 수 조회 (회원/비회원 구분)
+        const authToken = localStorage.getItem("authToken");
+        trackVisitor(authToken); // 방문자 기록 함수 실행
         // body에 클래스 추가
         document.body.classList.add(styles.homeBody);
 

--- a/src/pages/UserInquirePage/UserInquirePage.jsx
+++ b/src/pages/UserInquirePage/UserInquirePage.jsx
@@ -332,7 +332,7 @@ const UserInquirePage = () => {
                                         placeholder="메세지 입력"
                                         value={inputMessage}
                                         onChange={(e) => setInputMessage(e.target.value)} // 입력 값을 상태에 반영
-                                        onKeyPress={handleKeyPress} // Enter 키 이벤트 핸들러 추가
+                                        onKeyDown={handleKeyPress} // Enter 키 이벤트 핸들러 추가
                                     />
                                     {inputMessage.trim() && (
                                         <button className={styles.sendButton} onClick={handleSendMessage}>

--- a/src/utils/visitorTracker.js
+++ b/src/utils/visitorTracker.js
@@ -3,7 +3,14 @@ import { PATH } from "src/utils/path";
 export const trackVisitor = async (authToken = null) => {
     const today = new Date().toISOString().split("T")[0]; // 'YYYY-MM-DD' 형식
     const storedToday = localStorage.getItem("visited_today");
-    const guestId = getGuestId();
+
+    // 회원일 경우 guestId를 사용하지 않음
+    const isGuest = !authToken;
+
+    let guestId = null;
+    if (isGuest) {
+        guestId = getGuestId(); // 비회원일 경우에만 guestId 가져오기
+    }
 
     // 오늘 날짜와 저장된 날짜가 다르면 업데이트 및 API 호출
     if (storedToday !== today) {
@@ -16,7 +23,7 @@ export const trackVisitor = async (authToken = null) => {
                     "Content-Type": "application/json",
                     Authorization: authToken ? `Bearer ${authToken}` : "",
                 },
-                body: JSON.stringify({ guestId }),
+                body: JSON.stringify({ guestId }), // 비회원일 경우 guestId 전달
             });
 
             if (response.ok) {

--- a/src/utils/visitorTracker.js
+++ b/src/utils/visitorTracker.js
@@ -1,0 +1,45 @@
+import { PATH } from "src/utils/path";
+
+export const trackVisitor = async (authToken = null) => {
+    const today = new Date().toISOString().split("T")[0]; // 'YYYY-MM-DD' 형식
+    const storedToday = localStorage.getItem("visited_today");
+    const guestId = getGuestId();
+
+    // 오늘 날짜와 저장된 날짜가 다르면 업데이트 및 API 호출
+    if (storedToday !== today) {
+        console.log("새로운 날짜: 방문 기록 갱신 및 API 호출");
+
+        try {
+            const response = await fetch(`${PATH.SERVER}/api/trackVisit`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: authToken ? `Bearer ${authToken}` : "",
+                },
+                body: JSON.stringify({ guestId }),
+            });
+
+            if (response.ok) {
+                console.log("방문 기록 성공");
+                localStorage.setItem("visited_today", today); // 오늘 날짜 갱신
+            } else {
+                console.error("방문 기록 실패");
+            }
+        } catch (error) {
+            console.error("API 호출 오류:", error);
+        }
+    } else {
+        console.log("오늘 이미 방문 기록이 있음. API 호출 스킵");
+    }
+};
+
+// guestId를 가져오거나 생성
+const getGuestId = () => {
+    let guestId = localStorage.getItem("guestId");
+    if (!guestId) {
+        guestId = `guest_${Date.now()}_${Math.random()}`;
+        localStorage.setItem("guestId", guestId);
+        console.log("새로운 guestId 생성:", guestId);
+    }
+    return guestId;
+};


### PR DESCRIPTION
# 관리자 메인 페이지 그래프 및  일자별 요약

## 관리 메인 페이지

![image](https://github.com/user-attachments/assets/4f6d3196-e909-4c1d-9e91-9f3551095cfb)
- api 연동이 잘 된 모습입니다

## 회원 & 비회원 방문자 수 카운트

- 메인 페이지(http://localhost:5173)에 접속 했을 경우의 기반으로 방문자 수를 카운트 했습니다.

1. 비회원

- 비회원으로 접속했을 경우에는 guestId와 visited_today가 나옵니다.

- 로컬 스토리지가  비어 있을 경우(강제로 지움)
![image](https://github.com/user-attachments/assets/b7fe2589-1706-4fc3-a5ba-fa1b61712a1d)
- 다시 접속하면 guestId와 visited_today가 발급된 것을 볼 수 있습니다.
![image](https://github.com/user-attachments/assets/db5d8274-f171-49de-ad7c-f1fbba5f2ee2)

2. 회원

- 로컬 스토리지에 visited_today가 없을 경우
![image](https://github.com/user-attachments/assets/2cffc9a7-ae66-40b4-98e6-60cf12bcfb79)
- 다시 접속하면 visited_today가 발급된 것을 볼 수 있습니다.
![image](https://github.com/user-attachments/assets/b153e39c-02df-433e-85d7-373988954766)

## 회원 & 비회원 방문자 수 카운트 로직

- frontend에서는 `src/utils/visitorTracker.js` 에서 guestId와 visited_today를 발급합니다.
- 이를 사용하기 위해서는 useEffect를 통해서 `visitorTracker.js`에서 export한 `trackVisitor`를 token을 넣어주면 됩니다. (현재는 HomePage에 적용되어 있는 상태)
![image](https://github.com/user-attachments/assets/702fc0ff-610b-4221-b28c-808d4631eb44)

- 이때 외부 방문자의 경우에는 token이 없기 때문에 `visitorTracker.js`에서 `async (authToken = null)` 로 설정되어 있기 때문에 null을 허용합니다

- 발급한 guestId 또는 로컬 스토리지에 이미 있는 access token을 서버로 보내고 서버에서는 다음과  같이 처리합니다.

1. guest라면 guestId를 redis에 저장합니다
2. 회원이라면 회원 PK값을 redis에 저장합니다.
3. 정각이 되면 redis에 있는 `오늘 집계한 데이터`를 DB에 저장하고 기존에 redis에 있는 정보를 삭제합니다.
![image](https://github.com/user-attachments/assets/844f251e-f273-4c3e-b0c7-7b102fd748b4)