### PR TITLE
fix : 존재하지 않는 상품 모달 구현

### DIFF
--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import React, { useEffect, useState } from 'react';
+import { PATH } from "src/utils/path";
 
 const useProducts = (id) => {
     const [products, setProducts] = useState({
@@ -8,6 +9,8 @@ const useProducts = (id) => {
         product: null,
         conditions: []
     });
+
+    const [noIdMessage, setNoIdMessage] = useState(null);
 
     useEffect(() => {
         if (id) {
@@ -19,9 +22,16 @@ const useProducts = (id) => {
                         product: res.data.product,
                         conditions: res.data.conditions
                     });
+                    setNoIdMessage(null);
                     console.log(res.data);
                 })
-                .catch((e) => console.log(e));
+                .catch((error) => {
+                    if (error.response?.data?.message === "존재하지 않는 상품입니다.") {
+                        setNoIdMessage("존재하지 않는 상품입니다."); // 에러 메시지 저장
+                    } else {
+                        console.error("Failed to fetch product details:", error);
+                    }
+                });
         }
     }, [id]);
 
@@ -36,7 +46,8 @@ const useProducts = (id) => {
         optionNum,
         options,
         product,
-        conditions
+        conditions,
+        noIdMessage,
     };
 };
 

--- a/src/pages/ProductDetailPage/ProductDetailPage.jsx
+++ b/src/pages/ProductDetailPage/ProductDetailPage.jsx
@@ -11,6 +11,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { PATH } from "src/utils/path";
 import { atom, useAtom } from 'jotai';
+import useProducts from 'src/hooks/useProducts';
 import { useFavorite } from '../../hooks/useFavorite';
 import { getProductDetails } from 'src/apis/productsAPI';
 
@@ -31,7 +32,7 @@ const ProductDetailPage = () => {
     const { isFavorite, toggleFavorite, errorMessage } = useFavorite(prdId);
     const [isPopupOpen, setIsPopupOpen] = useState(false);
     const [favoriteClicked, setFavoriteClicked] = useState(false);
-
+    const { noIdMessage } = useProducts(prdId);
 
     /* Jotai 상태 관리 */
     const [products, setProducts] = useAtom(productsAtom);
@@ -203,16 +204,16 @@ const ProductDetailPage = () => {
 
     /* 유효하지 않은 상품 리다이렉트 팝업 */
     useEffect(() => {
-        if (errorMessage === "유효하지 않은 상품 ID입니다.") {
-          setIsPopupOpen(true); // 팝업 열기
+        if (noIdMessage) {
+            setIsPopupOpen(true); // 팝업 열기
         }
-      }, [errorMessage]);
+    }, [noIdMessage]);
 
     const popupMessage = (
-    <>
-        유효하지 않은 상품 ID입니다. <br />
-        목록으로 이동합니다.
-    </>
+        <>
+            {noIdMessage} <br />
+            목록으로 이동합니다.
+        </>
     );
 
     return (


### PR DESCRIPTION
# 유효하지 않은 상품 id 로 상품상세페이지 접근 시 모달 띄우기 
![image](https://github.com/user-attachments/assets/22ba9097-a5d2-4fe7-857e-5a8591565d45)

# 상세내용 
## checkFavorite 이 아닌 getOneProduct 에서 하는 것으로 수정

## 프론트에서 유효하지 않은 상품 id 로 접근 시 "존재하지 않는 상품입니다." 팝업 띄우기  & 3초 로딩 후 목록 페이지로 이동


# 추후 구현 (예금 목록, 적금 목록 페이지 완료된 후)
- DEPOSIT_LIST(예금 목록)에서 상세 페이지로 왔다면 DEPOSIT_LIST 로 리다이렉트
- DEPOSIT_LIST(적금 목록)에서 상세 페이지로 왔다면 INSTALLMENT_LIST 로 리다이렉트
- 그 외는 DEPOSIT_LIST로 리다이렉트