### PR TITLE
fix/calendar-token-handling  :   products조인 데이터 사용 및 수정

### DIFF
--- a/src/apis/axiosInstanceAPI.js
+++ b/src/apis/axiosInstanceAPI.js
@@ -57,7 +57,7 @@ api.interceptors.response.use(
         // 현재 토큰 가져오기
         const currentAccessToken = localStorage.getItem('Authorization');
         // 토큰 갱신 요청
-        const response = await api.post('/api/reissue', { access_token: `Bearer ${currentAccessToken}`);
+        const response = await api.post('/api/reissue', { access_token: `Bearer ${currentAccessToken}` });
         // 새로운 토큰 확인
         const newAccessToken = response.data.result;
         // 새로운 토큰 저장

--- a/src/pages/MyCalendarPage/MyCalendarPage.jsx
+++ b/src/pages/MyCalendarPage/MyCalendarPage.jsx
@@ -161,11 +161,11 @@ const MyCalendarPage = () => {
   useEffect(() => {
     const fetchBanks = async () => {
       const response = await axiosInstanceAPI.get(`${API_URL}/banks`);
-      setBanks(response.data); // 은행 데이터 저장
+      const result = response.data.result; // ApiResponse에서 result 가져오기
+      setBanks(result || []); // 결과 배열 설정 (없으면 빈 배열)
     };
     fetchBanks();
   }, []);
-
 
   // 이벤트 목록 가져오기
   const fetchEvents = async () => {
@@ -278,7 +278,8 @@ const MyCalendarPage = () => {
 
     // 적금명 목록 가져오기
     const response = await axiosInstanceAPI.get(`${API_URL}/banks/${bankName}/products`);
-    setProducts(response.data);
+    console.log(response.data);
+    setProducts(response.data.result || []);
 
     // 로고 업데이트
     const selectedBank = banks.find((bank) => bank.bankName === bankName);
@@ -372,15 +373,21 @@ const MyCalendarPage = () => {
     // 적금명 리스트 가져오기
     if (bankName) {
       const response = await axiosInstanceAPI.get(`${API_URL}/banks/${bankName}/products`);
-      setProducts(response.data); // 적금명 리스트 업데이트
+      const productList = response.data.result || []; // 적금명 리스트 가져오기
+      setProducts(productList); // 상태에 적금명 리스트 업데이트
 
-      // 현재 적금명을 포함하도록 상태 설정
-      if (response.data.includes(extendedProps.installment_name)) {
-        setSavingName(extendedProps.installment_name);
+      // 적금명이 응답 리스트에 존재하는 경우 상태 업데이트
+      const matchedProduct = productList.find((product) => product === extendedProps.installment_name);
+      if (matchedProduct) {
+        setSavingName(matchedProduct); // 적금명 상태 업데이트
+      } else {
+        setSavingName(''); // 적금명을 찾지 못하면 기본값
       }
+      setProducts([]);
+      setSavingName('');
     }
     setModalIsOpen(true); // 모달 열기
-  }
+  };
 
   // 이벤트 목록을 백엔드(API)에서 가져옵니다
   useEffect(() => {
@@ -611,10 +618,11 @@ const MyCalendarPage = () => {
         <select
           value={selectedBank}
           onChange={(e) => handleBankChange(e.target.value)}
-          className={styles.modalInput}
+          className={styles.modalSelect}
         >
-          <option value="">은행 선택</option>
-          {banks.map((bank) => (
+        <option value="">은행 선택</option>
+        {Array.isArray(banks) &&
+          banks.map((bank) => (
             <option key={bank.bankName} value={bank.bankName}>
               {bank.bankName}
             </option>
@@ -624,10 +632,11 @@ const MyCalendarPage = () => {
         <select
           value={savingName}
           onChange={(e) => setSavingName(e.target.value)}
-          className={styles.modalInput}
+          className={styles.modalSelect}
         >
-          <option value="">적금명 선택</option>
-          {products.map((product, index) => (
+        <option value="">적금명 선택</option>
+        {Array.isArray(products) &&
+          products.map((product, index) => (
             <option key={index} value={product}>
               {product}
             </option>

--- a/src/pages/MyCalendarPage/MyCalendarPage.module.scss
+++ b/src/pages/MyCalendarPage/MyCalendarPage.module.scss
@@ -119,6 +119,7 @@
   border: 1px solid var(--divider-border);
   border-radius: 4px;
   font-size: 14px;
+  cursor: pointer; 
 }
 
 .modalButton {
@@ -146,9 +147,9 @@
   .deleteButton {
     flex: 1; /* 두 버튼의 너비를 동일하게 설정 */
     padding: 10px;
-    background-color: var(--main2); /* 기본 버튼 색상 */
+    background-color: var(--side-nav); /* 기본 버튼 색상 */
     color: var(--white); /* 글자 색상 */
-    border: none;
+    border: 1px solid #0056b3;
     border-radius: 4px;
     cursor: pointer;
     font-size: 16px;
@@ -156,14 +157,17 @@
     transition: background-color 0.3s ease;
 
     &:hover {
-      background-color: #006bbd; /* 호버 색상 */
+      background-color: #003f87; /* 호버 색상 */
+      border: 1px solid #003f87;
     }
   }
 
   .deleteButton {
-    background-color: var(--red1); /* 삭제 버튼 - 빨간색 */
+    background-color: var(--main2); 
+    border: 1px solid var(--main2);
     &:hover {
-      background-color: var(--red2); /* 삭제 버튼 호버 색상 */
+      background-color: var(--main1); 
+      border: 1px solid var(--main1);
     }
   }
 }


### PR DESCRIPTION
###  로고, 은행명, 적금명 => products테이블의 데이터로 사용

![20241226_130641](https://github.com/user-attachments/assets/ad6a9ffc-063d-43ef-baec-d201ab38bd35)

![20241226_130714](https://github.com/user-attachments/assets/667e545c-b15e-4ab3-818b-87bef744207f)

![20241226_130821](https://github.com/user-attachments/assets/c20edd08-c53d-4521-873e-183fc373bf02)

![20241226_130835](https://github.com/user-attachments/assets/54dce104-aa8f-4ec9-af55-d86b61adeba3)



### 백엔드 DTO에 최초 시작일 추가 

`반복되는 날짜의 시작일은 최초시작일로 고정되게 수정` 
`기존에는 01월 04일로 찍혀있었음`

![20241226_130902](https://github.com/user-attachments/assets/818269ec-8fe8-40f2-ab67-f1f827f41453)


###  그 외 수정 
만약 31일에 이벤트를 추가했을 때 30일, 28일 등 저장 안되던 문제를 
31일에 추가하더라도 말일에 잘 저장되게 수정 완료!


